### PR TITLE
Upgraded .NET version to net8.0 for quickstarts supporting CallAutoma…

### DIFF
--- a/CallAutomation_AzOpenAI_Voice/CallAutomation_AzOpenAI_Voice/CallAutomation_AzOpenAI_Voice.csproj
+++ b/CallAutomation_AzOpenAI_Voice/CallAutomation_AzOpenAI_Voice/CallAutomation_AzOpenAI_Voice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/CallAutomation_CallLiveTranscription/CallAutomationLiveTranscription/CallAutomation_LiveTranscription.csproj
+++ b/CallAutomation_CallLiveTranscription/CallAutomationLiveTranscription/CallAutomation_LiveTranscription.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/CallAutomation_OutboundCalling/CallAutomation_OutboundCalling/CallAutomation_OutboundCalling.csproj
+++ b/CallAutomation_OutboundCalling/CallAutomation_OutboundCalling/CallAutomation_OutboundCalling.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>d7d2fc43-754d-4dba-87ed-832e765c7a4d</UserSecretsId>

--- a/CallRecording/RecordingApi.csproj
+++ b/CallRecording/RecordingApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>

--- a/callautomation-openai-sample-csharp/CallAutomationOpenAI/CallAutomationOpenAI.csproj
+++ b/callautomation-openai-sample-csharp/CallAutomationOpenAI/CallAutomationOpenAI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
# Upgrade from .NET 7.0 to .NET 8.0 for CallAutomation samples.

Upgraded target framework from .NET 7.0 to .NET 8.0 for the following quick-start samples:
CallAutomation_AzOpenAI_Voice
CallAutomation_CallLiveTranscription
CallAutomation_OutboundCalling
CallRecording
callautomation-openai-sample-csharp

Validated all samples to ensure proper functionality.