### PR TITLE
Add sync and async endpoints for ACS call transfer

### DIFF
--- a/Call_Automation_GCCH/Call_Automation_GCCH/Controllers/CallController.cs
+++ b/Call_Automation_GCCH/Call_Automation_GCCH/Controllers/CallController.cs
@@ -131,7 +131,91 @@ namespace Call_Automation_GCCH.Controllers
                 return Problem($"Failed to create outbound ACS call: {ex.Message}");
             }
         }
-        
+        /// <summary>
+        /// Transfers a call to an ACS participant asynchronously
+        /// </summary>
+        /// <param name="callConnectionId">The call connection ID</param>
+        /// <param name="acsTransferTarget">The ACS user identifier to transfer to</param>
+        /// <param name="acsTarget">The ACS target identifier</param>
+        /// <returns>Call connection status</returns>
+        [HttpPost("/transferCallToAcsParticipantAsync")]
+        [Tags("Transfer Call APIs")]
+        public async Task<IActionResult> TransferCallToAcsParticipantAsync(string callConnectionId, string acsTransferTarget, string acsTarget)
+        {
+            try
+            {
+                _logger.LogInformation($"Starting async call transfer to ACS user: {acsTransferTarget} for call {callConnectionId}");
+                
+                CallConnection callConnection = _service.GetCallConnection(callConnectionId);
+                var correlationId = _service.GetCallConnectionProperties(callConnectionId).CorrelationId;
+                
+                TransferToParticipantOptions transferToParticipantOptions = new TransferToParticipantOptions(new CommunicationUserIdentifier(acsTransferTarget))
+                {
+                    OperationContext = "TransferCallContext",
+                    Transferee = new CommunicationUserIdentifier(acsTarget),
+                };
+
+                var transferResult = await callConnection.TransferCallToParticipantAsync(transferToParticipantOptions);
+                var status = transferResult.GetRawResponse().Status.ToString();
+                
+                _logger.LogInformation($"Call transferred successfully. CallConnectionId: {callConnectionId}, correlation id: {correlationId}, status: {status}");
+                
+                return Ok(new CallConnectionResponse 
+                { 
+                    CallConnectionId = callConnectionId,
+                    CorrelationId = correlationId,
+                    Status = status 
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error transferring call: {ex.Message}. CallConnectionId: {callConnectionId}");
+                return Problem($"Failed to transfer call: {ex.Message}");
+            }
+        }
+
+    /// <summary>
+        /// Transfers a call to an ACS participant synchronously
+        /// </summary>
+        /// <param name="callConnectionId">The call connection ID</param>
+        /// <param name="acsTransferTarget">The ACS user identifier to transfer to</param>
+        /// <param name="acsTarget">The ACS target identifier</param>
+        /// <returns>Call connection status</returns>
+        [HttpPost("/transferCallToAcsParticipant")]
+        [Tags("Transfer Call APIs")]
+        public IActionResult TransferCallToAcsParticipant(string callConnectionId, string acsTransferTarget, string acsTarget)
+        {
+            try
+            {
+                _logger.LogInformation($"Starting call transfer to ACS user: {acsTransferTarget} for call {callConnectionId}");
+                
+                CallConnection callConnection = _service.GetCallConnection(callConnectionId);
+                var correlationId = _service.GetCallConnectionProperties(callConnectionId).CorrelationId;
+                
+                TransferToParticipantOptions transferToParticipantOptions = new TransferToParticipantOptions(new CommunicationUserIdentifier(acsTransferTarget))
+                {
+                    OperationContext = "TransferCallContext",
+                    Transferee = new CommunicationUserIdentifier(acsTarget),
+                };
+
+                var transferResult = callConnection.TransferCallToParticipant(transferToParticipantOptions);
+                var status = transferResult.GetRawResponse().Status.ToString();
+
+                _logger.LogInformation($"Call transferred successfully. CallConnectionId: {callConnectionId}, correlation id: {correlationId}, status: {status}");
+                
+                return Ok(new CallConnectionResponse 
+                { 
+                    CallConnectionId = callConnectionId,
+                    CorrelationId = correlationId,
+                    Status = status 
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error transferring call: {ex.Message}. CallConnectionId: {callConnectionId}");
+                return Problem($"Failed to transfer call: {ex.Message}");
+            }
+        }
         /// <summary>
         /// Hangs up a call asynchronously
         /// </summary>


### PR DESCRIPTION
Introduced new test endpoints in Call Controller to validate synchronous and asynchronous call transfer flows between ACS participants and target endpoints.

Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Adds testable endpoints to simulate and validate both synchronous and asynchronous ACS call transfer scenarios.

Helps ensure that transfers between participants and target endpoints behave as expected in different timing contexts.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. Run the application.
2. Use Swagger to call the new synchronous and asynchronous test endpoints.
3. Monitor logs or responses to verify correct behavior of call transfers.

```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->