### PR TITLE
Add region-based PMA endpoints and call transfer functionality

### DIFF
--- a/Call_Automation_GCCH/Call_Automation_GCCH/CallAutomationService.cs
+++ b/Call_Automation_GCCH/Call_Automation_GCCH/CallAutomationService.cs
@@ -6,16 +6,26 @@ namespace Call_Automation_GCCH.Services
 {
   public class CallAutomationService
   {
-    private readonly CallAutomationClient _client;
-    private readonly ILogger<CallAutomationService> _logger;
+    private CallAutomationClient _client;
+    private ILogger<CallAutomationService> _logger;
     private static string? _recordingLocation;
     private static string _recordingFileFormat = "mp4";
+    private string _currentPmaEndpoint = string.Empty;
 
     public CallAutomationService(string connectionString, string pmaEndpoint, ILogger<CallAutomationService> logger)
     {
-      _client = new CallAutomationClient(pmaEndpoint: new Uri(pmaEndpoint), connectionString: connectionString);
-     // _client = new CallAutomationClient(connectionString: connectionString);
       _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+      _currentPmaEndpoint = pmaEndpoint;
+      
+      if (!string.IsNullOrEmpty(pmaEndpoint))
+      {
+        _client = new CallAutomationClient(pmaEndpoint: new Uri(pmaEndpoint), connectionString: connectionString);
+      }
+      else
+      {
+        _logger.LogWarning("PmaEndpoint is empty. Creating CallAutomationClient without PmaEndpoint parameter.");
+        _client = new CallAutomationClient(connectionString: connectionString);
+      }
     }
 
     /// <summary>
@@ -103,6 +113,33 @@ namespace Call_Automation_GCCH.Services
         _logger.LogError(errorMessage);
         throw;
       }
+    }
+
+    /// <summary>
+    /// Updates the CallAutomationClient with new connection settings
+    /// </summary>
+    /// <param name="connectionString">The ACS connection string</param>
+    /// <param name="pmaEndpoint">The PMA endpoint to use</param>
+    public void UpdateClient(string connectionString, string pmaEndpoint)
+    {
+      _logger = _logger ?? throw new InvalidOperationException("Logger is not initialized");
+      _currentPmaEndpoint = pmaEndpoint;
+      
+      if (!string.IsNullOrEmpty(pmaEndpoint))
+      {
+        _client = new CallAutomationClient(pmaEndpoint: new Uri(pmaEndpoint), connectionString: connectionString);
+        _logger.LogInformation($"CallAutomationClient recreated with PMA endpoint: {pmaEndpoint}");
+      }
+      else
+      {
+        _logger.LogWarning("PmaEndpoint is empty. Creating CallAutomationClient without PmaEndpoint parameter.");
+        _client = new CallAutomationClient(connectionString: connectionString);
+      }
+    }
+
+    public string GetCurrentPmaEndpoint()
+    {
+      return _currentPmaEndpoint;
     }
 
     //Need Azure Cognitive services for this so in phase 2

--- a/Call_Automation_GCCH/Call_Automation_GCCH/Controllers/CallAutomationEventsController.cs
+++ b/Call_Automation_GCCH/Call_Automation_GCCH/Controllers/CallAutomationEventsController.cs
@@ -381,6 +381,74 @@ namespace Call_Automation_GCCH.Controllers
                 _logger.LogInformation($"Recording State: {recordingStateChanged.State}");
             }
         }
+
+        /// <summary>
+        /// Updates the IsArizona configuration and switches PMA endpoint accordingly
+        /// </summary>
+        /// <param name="isArizona">Boolean flag to determine which PMA endpoint to use</param>
+        /// <returns>Action result indicating success or error</returns>
+        [HttpPost("setRegion")]
+        public IActionResult SetRegion([FromBody] RegionConfigRequest request)
+        {
+            try
+            {
+                _logger.LogInformation($"Changing region configuration. IsArizona: {request.IsArizona}");
+                
+                // Get the current configuration section
+                var configSection = HttpContext.RequestServices.GetRequiredService<IConfiguration>().GetSection("CommunicationSettings");
+                
+                // Get the current endpoint being used to determine if an update is needed
+                string currentEndpoint = _service.GetCurrentPmaEndpoint() ?? string.Empty;
+                string newEndpoint = request.IsArizona 
+                    ? configSection["PmaEndpointArizona"] ?? string.Empty
+                    : configSection["PmaEndpointTexas"] ?? string.Empty;
+                
+                // Check if new endpoint is empty
+                if (string.IsNullOrEmpty(newEndpoint))
+                {
+                    _logger.LogWarning($"The {(request.IsArizona ? "PmaEndpointArizona" : "PmaEndpointTexas")} setting is empty");
+                }
+                    
+                // Only update if the endpoint would actually change
+                if (currentEndpoint == newEndpoint)
+                {
+                    if(string.IsNullOrEmpty(currentEndpoint))
+                    {
+                        return Ok($"Configuration unchanged as the endpoints are empty");
+                    }
+                    else
+                    {
+                        return Ok($"Configuration unchanged. Already using {(request.IsArizona ? "Arizona" : "Texas")} region.");
+                    }
+                }
+                
+                // Update the IsArizona setting in memory
+                ((IConfigurationSection)configSection.GetSection("IsArizona")).Value = request.IsArizona.ToString();
+                
+                // Update the client with the new endpoint
+                var connectionString = configSection["AcsConnectionString"] ?? string.Empty;
+                if (string.IsNullOrEmpty(connectionString))
+                {
+                    _logger.LogError("AcsConnectionString is empty");
+                    return Problem("AcsConnectionString is empty");
+                }
+                
+                _service.UpdateClient(connectionString, newEndpoint);
+                
+                return Ok($"Region updated successfully to {(request.IsArizona ? "Arizona" : "Texas")}.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error updating region configuration: {ex.Message}");
+                return Problem($"Failed to update region configuration: {ex.Message}");
+            }
+        }
+
+        // Request model for setting the region
+        public class RegionConfigRequest
+        {
+            public bool IsArizona { get; set; }
+        }
     }
 }
 

--- a/Call_Automation_GCCH/Call_Automation_GCCH/Program.cs
+++ b/Call_Automation_GCCH/Call_Automation_GCCH/Program.cs
@@ -22,7 +22,13 @@ builder.Services.AddSwaggerGen();
 // Add CallAutomationService as a singleton
 builder.Services.AddSingleton<CallAutomationService>(sp => {
     string connectionString = commSection["AcsConnectionString"];
-    string pmaEndpoint = commSection["PmaEndpoint"];
+    bool isArizona = bool.Parse(commSection["IsArizona"] ?? "true");
+    string pmaEndpoint = isArizona ? commSection["PmaEndpointArizona"] : commSection["PmaEndpointTexas"];
+    
+    if (string.IsNullOrEmpty(pmaEndpoint)) {
+        sp.GetRequiredService<ILogger<Program>>().LogWarning($"The {(isArizona ? "PmaEndpointArizona" : "PmaEndpointTexas")} setting is empty");
+    }
+    
     return new CallAutomationService(connectionString, pmaEndpoint, sp.GetRequiredService<ILogger<CallAutomationService>>());
 });
 

--- a/Call_Automation_GCCH/Call_Automation_GCCH/appsettings.json
+++ b/Call_Automation_GCCH/Call_Automation_GCCH/appsettings.json
@@ -11,6 +11,8 @@
         "AcsConnectionString": "",
         "AcsPhoneNumber": "",
         "CallbackUriHost": "",
-        "PmaEndpoint": ""
+        "PmaEndpointArizona": "",
+        "PmaEndpointTexas": "",
+        "IsArizona": true
     }
 }


### PR DESCRIPTION

- Add PMA endpoints for Arizona and Texas regions in app settings
- Implement dynamic endpoint selection based on config boolean in app settings
- Create setRegion endpoint to update PMA endpoint and reinitialize call automation client
- Add call transfer capability for ACS participants

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
* 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. Verify Arizona and Texas PMA endpoints are available in app settings
2. Test dynamic endpoint selection by toggling the config boolean
3. Test the setRegion endpoint functionality
4. Verify call transfer works correctly for ACS participants
```

## What to Check
Verify that the following are valid
* Verify that the following are valid:

PMA endpoints for Arizona and Texas are correctly implemented and accessible
The application correctly switches between endpoints based on the configuration setting
The setRegion endpoint properly updates the PMA endpoint and reinitializes the call automation client
Call transfers work as expected for ACS participants

## Other Information
<!-- Add any other helpful information that may be needed here. -->